### PR TITLE
V3.0.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 
 build:
-  number: 5
+  number: 6
   skip: True  # [win] 
 
 requirements:


### PR DESCRIPTION
must be link with the new version of libcdms-feedstock.