### PR TITLE
Add a patch to disable mpi4py with an env. var.

### DIFF
--- a/recipe/0005-env_flag_to_disable_mpi4py_in_regrid2.patch
+++ b/recipe/0005-env_flag_to_disable_mpi4py_in_regrid2.patch
@@ -1,0 +1,67 @@
+diff -ruN cdms-3.1.5/regrid2/Lib/esmf.py cdms-3.1.5-patch/regrid2/Lib/esmf.py
+--- cdms-3.1.5/regrid2/Lib/esmf.py	2020-07-31 03:01:33.000000000 +0200
++++ cdms-3.1.5-patch/regrid2/Lib/esmf.py	2021-06-09 15:18:29.043255491 +0200
+@@ -18,6 +18,9 @@
+ import ESMF
+ from functools import reduce
+ 
++from .util import getenv_bool
++
++
+ # constants
+ R8 = ESMF.TypeKind.R8
+ R4 = ESMF.TypeKind.R4
+@@ -463,7 +466,13 @@
+         # communicator
+         self.comm = None
+ 
++        mpi_disabled = getenv_bool("CDMS_NO_MPI", "False")
++
+         try:
++            # skip trying to load mpi4py module
++            if mpi_disabled:
++                raise Exception()
++
+             from mpi4py import MPI
+             self.comm = MPI.COMM_WORLD
+         except BaseException:
+diff -ruN cdms-3.1.5/regrid2/Lib/mvESMFRegrid.py cdms-3.1.5-patch/regrid2/Lib/mvESMFRegrid.py
+--- cdms-3.1.5/regrid2/Lib/mvESMFRegrid.py	2020-07-31 03:01:33.000000000 +0200
++++ cdms-3.1.5-patch/regrid2/Lib/mvESMFRegrid.py	2021-06-09 10:40:05.039237116 +0200
+@@ -22,9 +22,16 @@
+ except Exception:
+     os.environ['MPICH_INTERFACE_HOSTNAME'] = 'localhost'
+ 
++from .util import getenv_bool
++
+ ESMF.Manager(debug=False)
+ HAVE_MPI = False
++mpi_disabled = getenv_bool("CDMS_NO_MPI", "False")
++
+ try:
++    # skip trying to load mpi4py module
++    if mpi_disabled:
++        raise Exception()
+     from mpi4py import MPI
+     HAVE_MPI = True
+ except BaseException:
+diff -ruN cdms-3.1.5/regrid2/Lib/util.py cdms-3.1.5-patch/regrid2/Lib/util.py
+--- cdms-3.1.5/regrid2/Lib/util.py	1970-01-01 01:00:00.000000000 +0100
++++ cdms-3.1.5-patch/regrid2/Lib/util.py	2021-06-09 10:39:10.295311114 +0200
+@@ -0,0 +1,16 @@
++import os
++
++
++def getenv_bool(name, default=None):
++    valid_bool_str = ["true", "false"]
++    value = os.environ.get(name, default)
++
++    if value is None:
++        raise ValueError("{!r} was not set".format(name))
++
++    if value.lower() not in valid_bool_str:
++        raise ValueError(
++            "{!r} is not a valid value for {!r}, allowed values: {!r}".format(
++                value, name, valid_bool_str))
++
++    return value.lower() == "true"

--- a/recipe/0006-env_flag_to_disable_mpi4py_in_cdscan.patch
+++ b/recipe/0006-env_flag_to_disable_mpi4py_in_cdscan.patch
@@ -1,0 +1,24 @@
+diff -ruN cdms-3.1.5/Lib/cdscan.py cdms-3.1.5-patch/Lib/cdscan.py
+--- cdms-3.1.5/Lib/cdscan.py	2020-07-31 03:01:33.000000000 +0200
++++ cdms-3.1.5-patch/Lib/cdscan.py	2021-06-17 10:24:12.484410966 +0200
+@@ -18,6 +18,7 @@
+ from cdms2.error import CDMSError
+ from collections import OrderedDict
+ from six import string_types
++from cdsm2.util import getenv_bool
+ usage = """Usage:
+     cdscan [options] <files>
+ 
+@@ -1840,7 +1841,12 @@
+ # ------------------------------------------------------------------------
+ if __name__ == '__main__':
+     main(sys.argv)
++    mpi_disabled = getenv_bool("CDMS_NO_MPI", "False")
+     try:
++        # skip trying to load mpi4py module
++        if mpi_disabled:
++            raise Exception()
++
+         from mpi4py import MPI
+         comm = MPI.Comm.Get_parent()
+         comm.send('done', dest=0)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
     - 0003-Removes-modifying-ncmode-with-NC_NETCDF4-flag.patch
     - 0004-fix_add_env_flag_to_disable_mpi4py.patch
     - 0005-env_flag_to_disable_mpi4py_in_regrid2.patch
+    - 0006-env_flag_to_disable_mpi4py_in_cdscan.patch
 
 build:
   number: 7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,10 @@ source:
     - 0002-fixes_building_extensions.patch
     - 0003-Removes-modifying-ncmode-with-NC_NETCDF4-flag.patch
     - 0004-fix_add_env_flag_to_disable_mpi4py.patch
+    - 0005-env_flag_to_disable_mpi4py_in_regrid2.patch
 
 build:
-  number: 6
+  number: 7
   skip: True  # [win] 
 
 requirements:


### PR DESCRIPTION
This is similar to what was done in #68 for the `cdms2` package, but this time for the `regrid2` package and the `cdscan.py` script.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
