### PR TITLE
Patch to fix disabling `mpi4py` in `cdms2.dataset`

### DIFF
--- a/recipe/0007-fix_disable_mpi4py_in_dataset.patch
+++ b/recipe/0007-fix_disable_mpi4py_in_dataset.patch
@@ -1,0 +1,23 @@
+diff -ruN cdms-3.1.5/Lib/dataset.py cdms-3.1.5-patch/Lib/dataset.py
+--- cdms-3.1.5/Lib/dataset.py	2021-07-07 13:22:30.779860344 +0200
++++ cdms-3.1.5-patch/Lib/dataset.py	2021-07-07 13:23:05.811412427 +0200
+@@ -189,9 +189,6 @@
+        -------
+        No return value.
+     """
+-    if mpi_disabled:
+-        raise CDSMError("MPI support is disabled.")
+-
+     global CdMpi
+     if value not in [True, False, 0, 1]:
+         raise CDMSError(
+@@ -199,6 +196,9 @@
+     if value in [0, False]:
+         Cdunif.CdunifSetNCFLAGS("use_parallel", 0)
+     else:
++        if mpi_disabled:
++            raise CDMSError("MPI support is disabled.")
++
+         Cdunif.CdunifSetNCFLAGS("use_parallel", 1)
+         CdMpi = True
+         if not MPI.Is_initialized():

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,10 @@ source:
     - 0004-fix_add_env_flag_to_disable_mpi4py.patch
     - 0005-env_flag_to_disable_mpi4py_in_regrid2.patch
     - 0006-env_flag_to_disable_mpi4py_in_cdscan.patch
+    - 0007-fix_disable_mpi4py_in_dataset.patch
 
 build:
-  number: 8
+  number: 9
   skip: True  # [win] 
 
 requirements:


### PR DESCRIPTION
For `cdscan` to work when MPI is disabled, we need to be able to call `setNetcdfUseParallelFlag(0)`.  Before this patch, this
call attempted to raise an error but there was a typo in the error name (`CDSMError` instead of `CDMSError`), causing added confusion.  We only want to raise an error if the code is attempting to enable parallel NetCDF usage but MPI is disabled.

This patch is equivalent to https://github.com/CDAT/cdms/pull/439

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
