### PR TITLE
Bumps version, adds patches and pins cdtime/libcdms

### DIFF
--- a/recipe/0008-fixes-missing-PY_SSIZE_T_CLEAN-define.patch
+++ b/recipe/0008-fixes-missing-PY_SSIZE_T_CLEAN-define.patch
@@ -1,0 +1,24 @@
+From 466a16c70a65e70735030c174465c52715370078 Mon Sep 17 00:00:00 2001
+From: Jason Boutte <boutte.jason@gmail.com>
+Date: Tue, 16 Nov 2021 17:03:55 -0800
+Subject: [PATCH 1/7] Fixes missing PY_SSIZE_T_CLEAN define
+
+---
+ Src/_bindexmodule.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Src/_bindexmodule.c b/Src/_bindexmodule.c
+index 78136e4..1a27a7f 100644
+--- a/Src/_bindexmodule.c
++++ b/Src/_bindexmodule.c
+@@ -1,6 +1,7 @@
+ #ifdef __CPLUSPLUS__
+ extern "C" {
+ #endif
++#define PY_SSIZE_T_CLEAN
+ #include "Python.h"
+ #include "numpy/arrayobject.h"
+ #include "py3c.h"
+-- 
+2.25.1
+

--- a/recipe/0009-changes-int-to-Py_ssize_t-to-allow-PY_SSIZE_T_CLEAN.patch
+++ b/recipe/0009-changes-int-to-Py_ssize_t-to-allow-PY_SSIZE_T_CLEAN.patch
@@ -1,0 +1,29 @@
+From b54167a2128c67af90b3974ac1f0b6fb4222fc91 Mon Sep 17 00:00:00 2001
+From: Jason Boutte <boutte.jason@gmail.com>
+Date: Wed, 17 Nov 2021 08:55:48 -0800
+Subject: [PATCH 6/7] Changes int to Py_ssize_t to allow PY_SSIZE_T_CLEAN
+ define
+
+---
+ Src/_bindexmodule.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Src/_bindexmodule.c b/Src/_bindexmodule.c
+index 1a27a7f..d7ed9fa 100644
+--- a/Src/_bindexmodule.c
++++ b/Src/_bindexmodule.c
+@@ -391,9 +391,9 @@ _bindex_intersect (PyObject* unused, PyObject* args) {
+     PyArrayObject* aPOINTS;
+     int ePOINTS[1];
+     char* LATIND;
+-    int nLATIND;
++    Py_ssize_t nLATIND;
+     char* LONIND;
+-    int nLONIND;
++    Py_ssize_t nLONIND;
+     aLATS = (PyArrayObject*) 0;
+     aLONS = (PyArrayObject*) 0;
+     aHEAD = (PyArrayObject*) 0;
+-- 
+2.25.1
+

--- a/recipe/0010-Adds-LongLong-type-for-CDML.patch
+++ b/recipe/0010-Adds-LongLong-type-for-CDML.patch
@@ -1,0 +1,64 @@
+From 0aafeb5dda0cb7101f1f1c64c6392674017fb633 Mon Sep 17 00:00:00 2001
+From: Jason Boutte <boutte.jason@gmail.com>
+Date: Tue, 16 Nov 2021 17:03:00 -0800
+Subject: [PATCH 1/8] Adds LongLong type for CDML
+
+---
+ Lib/CDML.py     | 6 +++---
+ Lib/cdmsNode.py | 2 ++
+ 2 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/Lib/CDML.py b/Lib/CDML.py
+index e21404d..152a5ca 100644
+--- a/Lib/CDML.py
++++ b/Lib/CDML.py
+@@ -66,7 +66,7 @@ class CDML:
+         dtd = {}
+         dtd['attr'] = {
+             'name': (Cdata, Required),
+-            'datatype': (("Char", "Byte", "Short", "Int", "Long", "Int64", "Float", "Double", "String"), Required),
++            'datatype': (("Char", "Byte", "Short", "Int", "Long", "LongLong", "Int64", "Float", "Double", "String"), Required),
+         }
+         dtd['axis'] = {
+             'id': (Id, Required),
+@@ -77,7 +77,7 @@ class CDML:
+             'comment': (Cdata, Implied),
+             'component': (Cdata, Implied),
+             'compress': (Cdata, Implied),
+-            'datatype': (("Char", "Byte", "Short", "Int", "Long", "Int64", "Float", "Double", "String"), Required),
++            'datatype': (("Char", "Byte", "Short", "Int", "Long", "LongLong", "Int64", "Float", "Double", "String"), Required),
+             'expand': (Idref, Implied),
+             'interval': (Cdata, Implied),
+             'isvar': (("true", "false"), "true"),
+@@ -150,7 +150,7 @@ class CDML:
+             'associate': (Cdata, Implied),
+             'axis': (Cdata, Implied),
+             'comments': (Cdata, Implied),
+-            'datatype': (("Char", "Byte", "Short", "Int", "Long", "Int64", "Float", "Double", "String"), Required),
++            'datatype': (("Char", "Byte", "Short", "Int", "Long", "LongLong", "Int64", "Float", "Double", "String"), Required),
+             'grid_name': (Cdata, Implied),
+             'grid_type': (Cdata, Implied),
+             'long_name': (Cdata, Implied),
+diff --git a/Lib/cdmsNode.py b/Lib/cdmsNode.py
+index b0162b5..65569e2 100644
+--- a/Lib/cdmsNode.py
++++ b/Lib/cdmsNode.py
+@@ -50,6 +50,7 @@ CdDatatypes = [
+     CdInt,
+     CdUInt,
+     CdLong,
++    CdLongLong,
+     CdInt64,
+     CdFloat,
+     CdDouble,
+@@ -87,6 +88,7 @@ CdToNumericType = {CdChar: 'c',
+                    CdInt: numpy.intc,
+                    CdUInt: numpy.uintc,
+                    CdLong: numpy.int_,
++                   CdLongLong: numpy.longlong,
+                    CdInt64: numpy.int64,
+                    CdUInt64: numpy.uint64,
+                    CdULongLong: numpy.ulonglong,
+-- 
+2.25.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,9 +16,12 @@ source:
     - 0005-env_flag_to_disable_mpi4py_in_regrid2.patch
     - 0006-env_flag_to_disable_mpi4py_in_cdscan.patch
     - 0007-fix_disable_mpi4py_in_dataset.patch
+    - 0008-fixes-missing-PY_SSIZE_T_CLEAN-define.patch
+    - 0009-changes-int-to-Py_ssize_t-to-allow-PY_SSIZE_T_CLEAN.patch
+    - 0010-Adds-LongLong-type-for-CDML.patch
 
 build:
-  number: 13
+  number: 14
   skip: True  # [win] 
 
 requirements:
@@ -31,10 +34,10 @@ requirements:
     - setuptools
     - cdat_info
     - numpy
-    - libcdms
+    - libcdms 3
     - libdrs_f
     - libdrs
-    - cdtime
+    - cdtime 3
     - openblas
     - lazy-object-proxy
     - libnetcdf
@@ -45,16 +48,16 @@ requirements:
     - libcf
     - distarray
     - lazy-object-proxy
-    - cdtime
+    - cdtime 3
     - cdat_info
     - {{ pin_compatible('numpy') }}
     - esmf
     - esmpy
     - six
-    - libcdms
+    - libcdms 3
     - libdrs_f
     - libdrs
-    - cdtime
+    - cdtime 3
     - openblas
     - libnetcdf
     - jasper


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Fixes
- PY_SSIZE_T_CLEAN and Py_ssize_t issue with python 3.10 and osx causing seg fault
- Missing cdscan data types
- Pins cdtime/libcdms in preparation of major bump to remove libdrs/libdrs_f