### PR TITLE
Patch to fix esmpy import for esmpy >= 8.4.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -23,11 +23,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.ci_support/migrations/jasper4.yaml
+++ b/.ci_support/migrations/jasper4.yaml
@@ -1,8 +1,0 @@
-migrator_ts: 1678798913
-__migrator:
-  kind: version
-  migration_number: 1
-  bump_number: 1
-
-jasper:
-  - 4

--- a/.ci_support/migrations/libnetcdf491.yaml
+++ b/.ci_support/migrations/libnetcdf491.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libnetcdf:
-- 4.9.1
-migrator_ts: 1676063819.0284579

--- a/.ci_support/migrations/libnetcdf492.yaml
+++ b/.ci_support/migrations/libnetcdf492.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libnetcdf:
-- 4.9.2
-migrator_ts: 1678915697.6091654

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -55,7 +55,6 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
@@ -71,6 +70,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
+
     conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml

--- a/recipe/0013-esmpy-imports.patch
+++ b/recipe/0013-esmpy-imports.patch
@@ -1,0 +1,68 @@
+diff -ruN cdms-3.1.5/regrid2/Lib/esmf.py cdms-3.1.5-patch/regrid2/Lib/esmf.py
+--- cdms-3.1.5/regrid2/Lib/esmf.py	2020-07-31 03:01:33.000000000 +0200
++++ cdms-3.1.5-patch/regrid2/Lib/esmf.py	2023-08-01 09:02:26.554853011 +0200
+@@ -15,7 +15,10 @@
+ import time
+ import numpy
+ from regrid2 import RegridError
+-import ESMF
++try:
++    import esmpy as ESMF
++except ImportError:
++    import ESMF
+ from functools import reduce
+ 
+ # constants
+diff -ruN cdms-3.1.5/regrid2/Lib/__init__.py cdms-3.1.5-patch/regrid2/Lib/__init__.py
+--- cdms-3.1.5/regrid2/Lib/__init__.py	2020-07-31 03:01:33.000000000 +0200
++++ cdms-3.1.5-patch/regrid2/Lib/__init__.py	2023-08-01 09:01:50.815080096 +0200
+@@ -14,7 +14,10 @@
+ from .mvGenericRegrid import GenericRegrid  # noqa
+ from .mvLibCFRegrid import LibCFRegrid  # noqa
+ try:
+-    import ESMF
++    try:
++        import esmpy as ESMF
++    except ImportError:
++        import ESMF
+     ESMF.deprecated.__globals__[
+         'warnings'].warn_explicit = ESMF.deprecated.__globals__['warnings'].formatwarning
+     from .mvESMFRegrid import ESMFRegrid  # noqa
+@@ -24,7 +27,10 @@
+ ESMF_HAS_BEEN_INITIALIZED = False
+ if not ESMF_HAS_BEEN_INITIALIZED:
+     try:
+-        import ESMF
++        try:
++            import esmpy as ESMF
++        except ImportError:
++            import ESMF
+         ESMF.deprecated.__globals__[
+             'warnings'].warn_explicit = ESMF.deprecated.__globals__['warnings'].formatwarning
+         ESMF.Manager(debug=False)
+diff -ruN cdms-3.1.5/regrid2/Lib/mvESMFRegrid.py cdms-3.1.5-patch/regrid2/Lib/mvESMFRegrid.py
+--- cdms-3.1.5/regrid2/Lib/mvESMFRegrid.py	2020-07-31 03:01:33.000000000 +0200
++++ cdms-3.1.5-patch/regrid2/Lib/mvESMFRegrid.py	2023-08-01 09:02:26.538853112 +0200
+@@ -12,7 +12,10 @@
+ import socket
+ import numpy
+ 
+-import ESMF
++try:
++    import esmpy as ESMF
++except ImportError:
++    import ESMF
+ from . import esmf
+ from . import RegridError
+ from .mvGenericRegrid import GenericRegrid
+diff -ruN cdms-3.1.5/regrid2/Lib/mytest.py cdms-3.1.5-patch/regrid2/Lib/mytest.py
+--- cdms-3.1.5/regrid2/Lib/mytest.py	2020-07-31 03:01:33.000000000 +0200
++++ cdms-3.1.5-patch/regrid2/Lib/mytest.py	2023-08-01 09:04:07.634210699 +0200
+@@ -1,2 +1,6 @@
+-import ESMF  # noqa
++try:
++    import esmpy as ESMF  # noqa
++except ImportError:
++    import ESMF  # noqa
++
+ from .mvESMFRegrid import ESMFRegrid  # noqa

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,10 @@ source:
     - 0010-Adds-LongLong-type-for-CDML.patch
     - 0011-remove-numpy-float-int.patch
     - 0012-remove-libdrs-rename-libgrib2c.patch
+    - 0013-esmpy-imports.patch
 
 build:
-  number: 20
+  number: 21
   skip: True  # [win] 
 
 requirements:
@@ -69,6 +70,7 @@ test:
     - python -c 'import regrid2'
     - python -c 'import regrid2._regrid'
     - python -c 'import regrid2._scrip'
+    - python -c 'from regrid2 import ESMFRegrid'
     - cdscan --help
 
 about:


### PR DESCRIPTION
Add a test to make sure `regrid2.ESMFREgrid` is available.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
